### PR TITLE
0.新增security过滤器，请求中携带jwt，解析后判断，有效则可以直接访问，否则还是走登录逻辑，返回一个错误信息

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>java-jwt</artifactId>
             <version>4.3.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+            <version>3.5.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/dev/example/config/SecurityConfiguration.java
+++ b/src/main/java/dev/example/config/SecurityConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 @Configuration
 public class SecurityConfiguration {
@@ -80,7 +81,7 @@ public class SecurityConfiguration {
                                         Authentication authentication) throws IOException, ServletException {
         //获取用户信息
         User user = (User) authentication.getPrincipal();
-        String token = jwtUtils.generateToken(user, 1, "john");
+        String token = jwtUtils.generateToken(user, 2, "john");
         //相关视图对象
         AuthorizedVO authorizedVO = new AuthorizedVO();
         authorizedVO.setUsername(user.getUsername());
@@ -107,6 +108,14 @@ public class SecurityConfiguration {
     public void onLogoutSuccess(HttpServletRequest request,
                                 HttpServletResponse response,
                                 Authentication authentication) throws IOException, ServletException {
+        //设置返回格式和编码
+        response.setContentType("application/json;charset=utf-8");
+        PrintWriter writer = response.getWriter();
+        if (jwtUtils.invalidateJwt(request.getHeader("Authorization"))) {
+            writer.write(Rest.success().asJsonString());
+        } else {
+            writer.write(Rest.failure(400, "退出登录失败").asJsonString());
+        }
 
     }
 }

--- a/src/main/java/dev/example/config/SecurityConfiguration.java
+++ b/src/main/java/dev/example/config/SecurityConfiguration.java
@@ -1,8 +1,10 @@
 package dev.example.config;
 
 import dev.example.entity.Rest;
+import dev.example.entity.dto.Account;
 import dev.example.entity.response.AuthorizedVO;
 import dev.example.filter.JwtAuthorizeFilter;
+import dev.example.service.AccountService;
 import dev.example.utils.JwtUtils;
 import jakarta.annotation.Resource;
 import jakarta.servlet.ServletException;
@@ -17,7 +19,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -31,6 +32,9 @@ public class SecurityConfiguration {
 
     @Resource
     JwtAuthorizeFilter jwtAuthorizeFilter;
+
+    @Resource
+    AccountService service;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -81,11 +85,12 @@ public class SecurityConfiguration {
                                         Authentication authentication) throws IOException, ServletException {
         //获取用户信息
         User user = (User) authentication.getPrincipal();
-        String token = jwtUtils.generateToken(user, 2, "john");
+        Account account = service.findByUsernameOrEmail(user.getUsername());
+        String token = jwtUtils.generateToken(user, account.getId(), account.getUsername());
         //相关视图对象
         AuthorizedVO authorizedVO = new AuthorizedVO();
-        authorizedVO.setUsername(user.getUsername());
-        authorizedVO.setRole("ROLE_USER");
+        authorizedVO.setUsername(account.getUsername());
+        authorizedVO.setRole(account.getRole());
         authorizedVO.setToken(token);
         authorizedVO.setExpire(jwtUtils.expireLDT());
         //设置返回格式和编码

--- a/src/main/java/dev/example/config/WebConfiguration.java
+++ b/src/main/java/dev/example/config/WebConfiguration.java
@@ -1,0 +1,13 @@
+package dev.example.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class WebConfiguration {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/dev/example/entity/dto/Account.java
+++ b/src/main/java/dev/example/entity/dto/Account.java
@@ -1,0 +1,23 @@
+package dev.example.entity.dto;
+
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("account")
+@AllArgsConstructor
+public class Account {
+    @TableId(type = IdType.AUTO)
+    private int id;
+    private String username;
+    private String password;
+    private String email;
+    private String role;
+    private LocalDateTime registerTime;
+}

--- a/src/main/java/dev/example/filter/JwtAuthorizeFilter.java
+++ b/src/main/java/dev/example/filter/JwtAuthorizeFilter.java
@@ -10,7 +10,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -33,7 +32,7 @@ public class JwtAuthorizeFilter extends OncePerRequestFilter {
             authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authToken);
 
-//            request.setAttribute("id", jwt.getId());
+//            request.setAttribute("id", jwt.getId()); //这个不行因为这个id是jwtId不是用户id
 //            request.setAttribute("id", jwtUtils.toId());
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/dev/example/mapper/AccountMapper.java
+++ b/src/main/java/dev/example/mapper/AccountMapper.java
@@ -1,0 +1,10 @@
+package dev.example.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import dev.example.entity.dto.Account;
+import org.apache.ibatis.annotations.Mapper;
+
+
+@Mapper
+public interface AccountMapper extends BaseMapper<Account> {
+}

--- a/src/main/java/dev/example/service/AccountService.java
+++ b/src/main/java/dev/example/service/AccountService.java
@@ -1,0 +1,11 @@
+package dev.example.service;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+import dev.example.entity.dto.Account;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+
+public interface AccountService extends IService<Account>, UserDetailsService {
+    Account findByUsernameOrEmail(String text);
+}

--- a/src/main/java/dev/example/service/impl/AccountServiceImpl.java
+++ b/src/main/java/dev/example/service/impl/AccountServiceImpl.java
@@ -1,0 +1,33 @@
+package dev.example.service.impl;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import dev.example.entity.dto.Account;
+import dev.example.mapper.AccountMapper;
+import dev.example.service.AccountService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> implements AccountService {
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Account account = this.findByUsernameOrEmail(username);
+        if (account == null) {
+            throw new UsernameNotFoundException(username);
+        }
+        return User.withUsername(username)
+                .password(account.getPassword())
+                .roles(account.getRole())
+                .build();
+    }
+
+    @Override
+    public Account findByUsernameOrEmail(String text) {
+        return this.query()
+                .eq("username", text).or()
+                .eq("email", text)
+                .one();
+    }
+}

--- a/src/main/java/dev/example/utils/Const.java
+++ b/src/main/java/dev/example/utils/Const.java
@@ -1,0 +1,5 @@
+package dev.example.utils;
+
+public class Const {
+    public static final String JWT_BLACK_LIST = "jwt:blacklist:";
+}

--- a/src/main/java/dev/example/utils/JwtUtils.java
+++ b/src/main/java/dev/example/utils/JwtUtils.java
@@ -6,7 +6,9 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.JWTVerifier;
+import jakarta.annotation.Resource;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,8 +18,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class JwtUtils {
@@ -28,6 +29,50 @@ public class JwtUtils {
     @Value("${spring.security.jwt.expire}")
     private int expire;
 
+    @Resource
+    StringRedisTemplate template;
+
+    public boolean invalidateJwt(String authHeader) {
+        //获取jwt令牌内容
+        String token = this.convertToken(authHeader);
+        if (token == null) return false;
+
+        //选择加密算法和key生成Algorithm，用于验证签名
+        Algorithm algorithm = Algorithm.HMAC256(key);
+
+        //创建algorithm对应的JWT验证器
+        JWTVerifier verifier = JWT.require(algorithm).build();
+
+        try {
+            //verify方法验证token内容（没有抛出异常说明token是我们签发的），并验证token有没有过期
+            DecodedJWT jwt = verifier.verify(token);
+            String id = jwt.getId();
+            System.out.println("invalid:"+id);
+            return addTokenToBlackList(id, jwt.getExpiresAt());
+        } catch (JWTVerificationException e) {
+            return false;
+        }
+    }
+
+    public boolean addTokenToBlackList(String uuid, Date time) {
+        //判断这个jwt是否在redis的黑名单中
+        if (isInBlackList(uuid)) {
+            return true;
+        }
+        //计算jwt的剩余有效时长
+        //可能这个jwt已经过期，此时expire为负数，此时将其有效时长记为0即可
+        //此处有一个坑，set过期时长为0会报错，必须>=0
+        Date now = new Date();
+        long expire = Math.max(time.getTime()- now.getTime(), 0);
+        //将jwt存入redis的黑名单中
+        template.opsForValue().set(Const.JWT_BLACK_LIST + uuid, "", expire, TimeUnit.MICROSECONDS);
+        return true;
+    }
+
+    //从redis中查询黑名单是否有jwt的uuid
+    public boolean isInBlackList(String uuid) {
+        return Boolean.TRUE.equals(template.hasKey(Const.JWT_BLACK_LIST + uuid));
+    }
 
     //从Authorization头中解析jwt
     public DecodedJWT resolveJwt(String authHeader) {
@@ -44,9 +89,14 @@ public class JwtUtils {
         try {
             //verify方法验证token内容（没有抛出异常说明token是我们签发的），并验证token有没有过期
             //如果一切正常，返回解码后的DecodedJWT对象
-            DecodedJWT verify = verifier.verify(token);
-            Date expires = verify.getExpiresAt();
-            return new Date().after(expires) ? null : verify;
+            DecodedJWT jwt = verifier.verify(token);
+            //过滤存在黑名单中的jwt
+            if (isInBlackList(jwt.getId())) {
+                System.out.println("resolve:"+jwt.getId());
+                return null;
+            }
+            Date expires = jwt.getExpiresAt();
+            return new Date().after(expires) ? null : jwt;
         } catch (JWTVerificationException e) {
             return null;
         }
@@ -69,10 +119,15 @@ public class JwtUtils {
                 .build();
     }
 
+    public Integer toId(DecodedJWT token) {
+        return token.getClaim("id").asInt();
+    }
+
 
     public String generateToken(UserDetails userDetails, int id, String username) {
         Algorithm algorithm = Algorithm.HMAC256(key);
         return JWT.create()
+                .withJWTId(UUID.randomUUID().toString())
                 .withClaim("id", id)
                 .withClaim("name", username)
                 .withClaim("authorities", userDetails

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,16 @@ spring:
       host: 127.0.0.1
       port: 6379
       database: 0
+  datasource:
+    url: jdbc:mysql://120.26.110.12:49162/dev_project
+    hikari:
+      username: dev
+      password: p@$$w0rd
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+
+
+
 server:
   port: 9090
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,5 +5,11 @@ spring:
     jwt:
       key: abcdefghijk
       expire: 6
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+      database: 0
 server:
   port: 9090
+

--- a/src/test/java/dev/example/FullProjectApplicationTests.java
+++ b/src/test/java/dev/example/FullProjectApplicationTests.java
@@ -1,13 +1,21 @@
 package dev.example;
 
+import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @SpringBootTest
 class FullProjectApplicationTests {
 
+    @Resource
+    StringRedisTemplate template;
+
     @Test
     void contextLoads() {
+        template.opsForValue().set("key", "val");
+        System.out.println(template.opsForValue().get("key"));
     }
 
 }

--- a/src/test/java/dev/example/FullProjectApplicationTests.java
+++ b/src/test/java/dev/example/FullProjectApplicationTests.java
@@ -5,17 +5,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootTest
 class FullProjectApplicationTests {
 
-    @Resource
-    StringRedisTemplate template;
+
 
     @Test
     void contextLoads() {
-        template.opsForValue().set("key", "val");
-        System.out.println(template.opsForValue().get("key"));
+        System.out.println(new BCryptPasswordEncoder().encode("123456"));
     }
 
 }


### PR DESCRIPTION
1.签发jwt时新增jwtid，用于redis的jwt黑名单
2.新增Const，其中存放一些常用常量；新增前缀"jwt:black:"，因为redis不止存放令牌黑名单，故使用前缀区分 3.新增使jwt令牌失效的方法（通过拉黑jwt对应的唯一的uuid实现），包括辅助方法：判断jwt是否在黑名单中，添加jwt到黑名单中 4.在解析jwt令牌时添加过滤逻辑，不解析被加入黑名单的jwt
5.补完security中的登出逻辑
6.新增toId方法从解析完的jwt中获取id（目前暂时用不到）